### PR TITLE
Show shortest cycle containing each node

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prepublish": "babel src -d lib",
-    "build": "babel src -d lib",
+    "build": "babel src -d lib --source-maps inline",
     "lint": "eslint src",
     "lint-all": "eslint ."
   },

--- a/src/file.js
+++ b/src/file.js
@@ -9,7 +9,7 @@ import type {Edge} from './types';
 
 // TODO: Remove this when upgrading to babel 7
 // Patch VISITOR_KEYS because it lags behind the parser ...
-VISITOR_KEYS['ObjectTypeSpreadProperty'] = ["argument"];
+VISITOR_KEYS['ObjectTypeSpreadProperty'] = ['argument'];
 
 
 function* childrenOf(node: ?Object): Iterator<Object> {

--- a/src/main.js
+++ b/src/main.js
@@ -217,7 +217,7 @@ if (args.verbose) {
 }
 const cycles = findSmallestCycles(findCycles(graph.values())).
     filter(cycle => cycle.length > 1).
-    map(cycle => cycle.map(node => node.file));
+    map(cycle => cycle.map(node => node.file).sort((a, b) => a.localeCompare(b)));
 if (cycles.length > 0) {
   process.stderr.write('Found cycles:\n');
   process.stderr.write(JSON.stringify(cycles, null, 4));

--- a/src/main.js
+++ b/src/main.js
@@ -120,9 +120,9 @@ function printGraph(graph: Map<string, Node>): void {
 
 const args = yargs
   .option('verbose', {
-	   type: 'boolean',
-     default: false,
-     description: 'Show verbose output while parsing'
+    type: 'boolean',
+    default: false,
+    description: 'Show verbose output while parsing',
   }).option('types', {
     type: 'boolean',
     default: false,


### PR DESCRIPTION
Change reporting of cycles to be more compact. Postprocess the strongly connected components to show, for each node, the shortest possible cycle that contains that node. The theory is that this will demonstrate the easiest places in code to fix the cycles.